### PR TITLE
Feature: Add barebones implementation of Suggestion events

### DIFF
--- a/web/src/components/suggestion/Suggestion.vue
+++ b/web/src/components/suggestion/Suggestion.vue
@@ -31,7 +31,7 @@
       </suggestion-content>
     </div>
 
-    <div v-if="events">
+    <div v-if="events.length > 0">
       <div v-for="event in events" :key="event.id">
         <suggestion-event
           :event="event"

--- a/web/src/components/suggestion/Suggestion.vue
+++ b/web/src/components/suggestion/Suggestion.vue
@@ -30,14 +30,23 @@
         :s="suggestion">
       </suggestion-content>
     </div>
+
+    <div v-if="events">
+      <div v-for="event in events" :key="event.id">
+        <suggestion-event
+          :event="event"
+          :type="event.event_type">
+        </suggestion-event>
+      </div>
+    </div>
   </div>
 </template>
-
 
 <script>
 import axios from 'axios';
 
 import SuggestionContent from './SuggestionContent';
+import SuggestionEvent from './events/SuggestionEvent';
 import IconArrow from '../icons/IconArrow';
 import IconMore from '../icons/IconMore';
 import SvgIcon from '../icons/SvgIcon';
@@ -45,12 +54,14 @@ import SvgIcon from '../icons/SvgIcon';
 export default {
   components: {
     SuggestionContent,
+    SuggestionEvent,
     IconArrow,
     IconMore,
     SvgIcon
   },
   data: () => ({
-    suggestion: null
+    suggestion: null,
+    events: []
   }),
   created() {
     // TODO: Use getters
@@ -64,6 +75,19 @@ export default {
       })
       .catch(e => {
         console.log('Error in fetching Suggestion data: ');
+        console.log(e);
+      });
+    axios
+      .get(
+        'http://localhost:8080/api/suggestions/' +
+          this.$route.params.suggestionID +
+          '/events'
+      )
+      .then(response => {
+        this.events = response.data.data;
+      })
+      .catch(e => {
+        console.log('Error in fetching Suggestion events: ');
         console.log(e);
       });
   },

--- a/web/src/components/suggestion/events/SuggestionEvent.vue
+++ b/web/src/components/suggestion/events/SuggestionEvent.vue
@@ -1,0 +1,112 @@
+<template>
+<div class="event">
+  <div class="event-divider"></div>
+
+  <div class="event-container">
+    <div class="event-header">
+      <div class="event-user-initials"></div>
+      <div class="event-info">
+        <p class="event-user">
+          <span class="user-name">{{ userName }} </span>
+          <span v-if="type == 'ACTION'">{{ action }}</span>
+        </p>
+        <p class="date-sent">Lähetetty 5 päivää sitten</p>
+      </div>
+    </div>
+
+    <div v-if="type == 'COMMENT'" class="event-comment">
+      <p>{{ event.text }}</p>
+    </div>
+  </div>
+</div>
+
+</template>
+
+<script>
+export default {
+  props: {
+    event: {
+      type: Object,
+      required: true
+    },
+    type: {
+      type: String,
+      required: true
+    }
+  },
+  data: () => ({
+    userInitials: 'MP',
+    userName: 'Miki Pernu',
+    action: 'vaihtoi tyypiksi '
+  })
+};
+</script>
+
+<style scoped>
+div.event-divider {
+  display: inline-block;
+  text-align: center;
+  width: 2px;
+  height: 40px;
+  margin-top: 20px;
+  background-color: #dddddd;
+}
+
+div.event-container {
+  width: 100%;
+  background-color: #ffffff;
+  border: 2px solid #f5f5f5;
+  text-align: left;
+  margin-top: 10px;
+}
+
+div.event-header {
+  padding: 20px 40px;
+}
+
+div.event-header .event-user-initials {
+  display: inline-block;
+  height: 50px;
+  width: 50px;
+  background-color: #eeeeee;
+  vertical-align: middle;
+}
+
+div.event-header .event-info {
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: 20px;
+}
+
+div.event-header .event-info p {
+  vertical-align: middle;
+  margin: 0;
+}
+
+div.event-header .event-info .user-name {
+  font-weight: 600;
+  font-size: 16px;
+}
+
+div.event-header .event-info .date-sent {
+  font-size: 14px;
+}
+
+div.event-comment {
+  width: 100%;
+  border-top: 1px solid #f5f5f5;
+  padding: 10px 40px;
+  margin: 0;
+}
+
+@media (max-width: 700px) {
+  div.event-header {
+    padding: 20px;
+  }
+
+  div.event-comment {
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+}
+</style>

--- a/web/src/components/suggestion/events/SuggestionEvent.vue
+++ b/web/src/components/suggestion/events/SuggestionEvent.vue
@@ -10,7 +10,7 @@
           <span class="user-name">{{ userName }} </span>
           <span v-if="type == 'ACTION'">{{ action }}</span>
         </p>
-        <p class="date-sent">Lähetetty 5 päivää sitten</p>
+        <p class="date-sent">5 päivää sitten</p>
       </div>
     </div>
 


### PR DESCRIPTION
Suggestion's Events are fetched and listed underneath the Suggestion, as per the designs, with different Event types (Comments, Actions).

<img width="1061" alt="screen shot 2018-10-11 at 20 43 39" src="https://user-images.githubusercontent.com/6062294/46823306-7cf4b300-cd96-11e8-94a5-43c6b638e056.png">