### PR TITLE
refactor: map 'new' and 'modify' to different string in UI

### DIFF
--- a/web/src/components/suggestion/Suggestion.vue
+++ b/web/src/components/suggestion/Suggestion.vue
@@ -14,7 +14,7 @@
           <div class="suggestion-header-details">
             <span><strong>#{{ suggestions[0].id }} </strong></span>
             <span>Lähetetty 3 päivää sitten</span>
-            <span class="suggestion-type">{{ suggestions[0].suggestion_type }}</span>
+            <span class="suggestion-type">{{ suggestionTypeToString[suggestions[0].suggestion_type] }}</span>
             <span class="tag"
               v-if="suggestions[0].tags && suggestions[0].tags.length > 0"
               v-for="tag in suggestions[0].tags"
@@ -79,6 +79,8 @@ import {
 import { eventGetters, eventActions } from '../../store/modules/event/eventConsts.js';
 import { mapEventGetters, mapEventActions } from '../../store/modules/event/eventModule.js';
 
+import { suggestionTypeToString } from '../../utils/suggestionMappings.js';
+
 export default {
   components: {
     SuggestionContent,
@@ -96,7 +98,8 @@ export default {
   },
   data: () => ({
     // eslint-disable-next-line
-    userId: $cookies.get('logged_user_id')
+    userId: $cookies.get('logged_user_id'),
+    suggestionTypeToString
   }),
   computed: {
     ...mapSuggestionGetters({

--- a/web/src/components/suggestion/SuggestionItem.vue
+++ b/web/src/components/suggestion/SuggestionItem.vue
@@ -5,10 +5,7 @@
         <p class="title-row">
           <span class="item-name">{{ suggestion.preferred_label.fi }}</span>
           <span
-            :class="[suggestion.suggestion_type === modify
-              ? 'type-modify'
-              : 'type-new',
-            'tag']">{{ suggestion.suggestion_type }}
+            :class="[suggestionTypeToStyleClass[suggestion.suggestion_type], 'tag']">{{ suggestionTypeToString[suggestion.suggestion_type] }}
           </span>
           <span v-if="suggestion.tags.length > 0">
             <span class="tags tag" v-for="tag in suggestion.tags" :key="tag.label">
@@ -34,7 +31,7 @@
 <script>
 import SvgIcon from '../icons/SvgIcon';
 import IconComments from '../icons/IconComments';
-import { suggestionType } from '../../utils/suggestionMappings.js';
+import { suggestionTypeToStyleClass, suggestionTypeToString } from '../../utils/suggestionMappings.js';
 import { dateDiffLabel } from '../../utils/dateTimeStampHelper.js';
 
 export default {
@@ -50,7 +47,8 @@ export default {
   },
   data:() => ({
     //not the best way but seems that you cannot use imported module straight inside class binding clause
-    modify: suggestionType.MODIFY
+    suggestionTypeToStyleClass,
+    suggestionTypeToString
   }),
   methods: {
     buildLabel() {

--- a/web/src/utils/suggestionMappings.js
+++ b/web/src/utils/suggestionMappings.js
@@ -17,6 +17,16 @@ export const suggestionType = {
   MODIFY: 'MODIFY'
 };
 
+export const suggestionTypeToString = {
+  NEW: 'Käsite-ehdotus',
+  MODIFY: 'Käsitemuutos'
+};
+
+export const suggestionTypeToStyleClass = {
+  NEW: 'type-new',
+  MODIFY: 'type-modify'
+};
+
 export const filterType = {
   STATUS: 'status',
   TAG: 'tag',


### PR DESCRIPTION
Change strings for suggestion types: "uusi" -> "käsite-ehdotus", "muutos" -> "käsitemuutos".