### PR TITLE
fix: set default status for new suggestion to 'RECEIVED'

### DIFF
--- a/api/api/logic/suggestions.py
+++ b/api/api/logic/suggestions.py
@@ -110,7 +110,11 @@ def post_suggestion() -> str:
 
     :returns: the created suggestion as json
     """
-    created_response = create_or_400(Suggestion, connexion.request.json)
+
+    payload_dict = connexion.request.json
+    payload_dict['status'] = 'RECEIVED'
+
+    created_response = create_or_400(Suggestion, payload_dict)
     response = created_response[0]
 
     if response is not None and response['code'] is 201:


### PR DESCRIPTION
* when creating new suggestion through api, it will add status as received as default status